### PR TITLE
Fix #1 (Capability not being registered)

### DIFF
--- a/src/main/java/subaraki/pga/capability/ScreenCapability.java
+++ b/src/main/java/subaraki/pga/capability/ScreenCapability.java
@@ -17,7 +17,7 @@ public class ScreenCapability {
     /*
      * This registers our capability to the manager
      */
-    public void register() {
+    public static void register() {
 
         CapabilityManager.INSTANCE.register(
 

--- a/src/main/java/subaraki/pga/mod/ScreenMod.java
+++ b/src/main/java/subaraki/pga/mod/ScreenMod.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import subaraki.pga.capability.ScreenCapability;
 import subaraki.pga.event.EventRegistry;
 import subaraki.pga.event.client.OpenGuiEventHandler;
 import subaraki.pga.network.NetworkHandler;
@@ -31,7 +32,7 @@ public class ScreenMod {
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-
+        ScreenCapability.register();
         new EventRegistry();
         new NetworkHandler();
     }


### PR DESCRIPTION
This PR fixes #1 

Your capability wasn't being registered, so ScreenCapability.CAPABILITY was null.

The reason why the mod appeared to function normally in your capability provider is because null == null.

```java
    @SuppressWarnings("unchecked")
    @Override
    public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {

        if (cap == ScreenCapability.CAPABILITY) //null == null
            return (LazyOptional<T>) LazyOptional.of(this::getImpl);

        return LazyOptional.empty();
    }
```

The reason why it's crashing with CyclopsCore is because CyclopsCore checks to make sure that capabilities are not null. 

```java
    public DefaultCapabilityProvider(Capability<T> capabilityType, T capability) {
        Objects.requireNonNull(capabilityType,
                "The given capability can not be null, this is probably being called too early during init");
        this.capabilityGetter = () -> capabilityType;
        this.capability = Objects.requireNonNull(capability);
    }
```
    