### PR TITLE
fix crash on forge 41.0.94+

### DIFF
--- a/Common/src/main/resources/META-INF/mods.toml
+++ b/Common/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,6 @@
 modLoader="javafml" #mandatory
 license="GNU V3"
-loaderVersion="[40,)" #mandatory (40 is current forge version)
+loaderVersion="[41,)" #mandatory (41 is current forge version)
 issueTrackerURL="https://github.com/ArtixAllMighty/PublicGuiAnnouncement/issues"
 logoFile="logo.png" #optional
 
@@ -22,7 +22,7 @@ Shows a simple representation of the screen players are currently looking at
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[41,)" #mandatory
+    versionRange="[41.0.94,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER

--- a/Common/src/main/resources/META-INF/mods.toml
+++ b/Common/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ Shows a simple representation of the screen players are currently looking at
 
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.forge]] #optional
+[[dependencies.publicguiannouncement]] #optional
     # the modid of the dependency
     modId="forge" #mandatory
     # Does this dependency have to exist - if not, ordering below must be specified
@@ -28,9 +28,9 @@ Shows a simple representation of the screen players are currently looking at
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
     side="BOTH"
 # Here's another dependency
-[[dependencies.minecraft]]
+[[dependencies.publicguiannouncement]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.19)"
+    versionRange="[1.19,1.20)"
     ordering="NONE"
     side="BOTH"

--- a/Forge/src/main/java/subaraki/pga/event/ContainerEventHandler.java
+++ b/Forge/src/main/java/subaraki/pga/event/ContainerEventHandler.java
@@ -17,7 +17,7 @@ public class ContainerEventHandler {
     @SubscribeEvent
     public static void openContainerEvent(PlayerContainerEvent.Open event) {
         
-        if(event.getPlayer() instanceof ServerPlayer serverPlayer) {
+        if(event.getEntity() instanceof ServerPlayer serverPlayer) {
             sendUpdateScreenPacket(serverPlayer, event.getContainer().getClass().getName());
         }
     }
@@ -25,7 +25,7 @@ public class ContainerEventHandler {
     @SubscribeEvent
     public static void closeContainerEvent(PlayerContainerEvent.Close event) {
         
-        if(event.getPlayer() instanceof ServerPlayer serverPlayer) {
+        if(event.getEntity() instanceof ServerPlayer serverPlayer) {
             sendUpdateScreenPacket(serverPlayer, ForgeScreenData.CLOSE_SCREEN);
         }
     }

--- a/Forge/src/main/java/subaraki/pga/event/PlayerTracker.java
+++ b/Forge/src/main/java/subaraki/pga/event/PlayerTracker.java
@@ -18,7 +18,7 @@ public class PlayerTracker {
     public static void playerTracking(PlayerEvent.StartTracking event) {
         
         if(event.getTarget() instanceof ServerPlayer target) {
-            if(event.getPlayer() instanceof ServerPlayer me) {
+            if(event.getEntity() instanceof ServerPlayer me) {
                 //get server sided ref
                 //send ref to tracking
                 ForgeScreenData.get(target).ifPresent(data -> {

--- a/Forge/src/main/java/subaraki/pga/event/client/OpenGuiEventHandler.java
+++ b/Forge/src/main/java/subaraki/pga/event/client/OpenGuiEventHandler.java
@@ -1,7 +1,7 @@
 package subaraki.pga.event.client;
 
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.ScreenOpenEvent;
+import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import subaraki.pga.capability.ForgeScreenData;
@@ -18,7 +18,7 @@ import java.util.UUID;
 public class OpenGuiEventHandler {
 
     @SubscribeEvent
-    public static void openGuiEvent(ScreenOpenEvent event) {
+    public static void openGuiEvent(ScreenEvent.Opening event) {
 
         // minecraft sets screens twice to null for closing them.
         // no current workaround to reduce packet spam

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ common_server_run_name=Common Server
 
 
 # Forge
-forge_version=41.0.35
+forge_version=41.1.0
 //forge_ats_enabled=true
 
 # Fabric


### PR DESCRIPTION
forge 41.0.94 renamed some things, which made the mod crash on that and any newer forge versions. ([log](https://gist.github.com/adrianmgg/df84e1128d43127ddd346830a3dbacae#file-public-gui-announcement-forge-1-19-4-0-0-0-jar-latest-log-L20-L21))

this pr:
- upgrades forge to 41.1.0 (mod should still be compatible down to 41.0.94)
- updates things that were renamed in 41.0.94
- changes minimum forge version in mods.toml to 41.0.94
- fixes dependencies list in mods.toml so that exact minimum forge version will be checked on launch